### PR TITLE
update nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 [dependencies]
 lazy_static = "1"
 maplit = "1"
-nom = "6.0.0"
+nom = "6.2"
 regex = "1"
 unicode_categories = "0.1.1"
 


### PR DESCRIPTION
nom's dependency on an older version of lexical-core is breaking builds due to the stabilization of `BITS` in 1.53. Plus it should be updated anyways.