### PR TITLE
Update nom to 7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 [dependencies]
 lazy_static = "1"
 maplit = "1"
-nom = "6.0.0"
+nom = "7.0.0"
 regex = "1"
 unicode_categories = "0.1.1"
 


### PR DESCRIPTION
This fixes an issue where broken dependencies in nom 6.1.x would break builds that depend on them too because they fucked up their release.

See: https://github.com/myrrlyn/funty/issues/3