### PR TITLE
Upgrade to rust 2021 and drop itertools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["sql"]
 categories = ["development-tools"]
 
 [dependencies]
-itertools = "0.10"
 nom = "7.0.0"
 unicode_categories = "0.1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sqlformat"
 version = "0.1.8"
 authors = ["Josh Holmer <jholmer.in@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/shssoichiro/sqlformat-rs"
 repository = "https://github.com/shssoichiro/sqlformat-rs"

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -3,7 +3,6 @@ use crate::inline_block::InlineBlock;
 use crate::params::Params;
 use crate::tokenizer::{Token, TokenKind};
 use crate::{FormatOptions, QueryParams};
-use itertools::Itertools;
 use std::borrow::Cow;
 
 pub(crate) fn format(tokens: &[Token<'_>], params: &QueryParams, options: FormatOptions) -> String {
@@ -230,18 +229,20 @@ impl<'a> Formatter<'a> {
             .enumerate()
             .map(|(i, line)| {
                 if i == 0 {
-                    return line.to_string();
+                    return [line, "", ""];
                 }
                 if !line.starts_with(|c| c == ' ' || c == '\t') {
-                    return line.to_string();
+                    return [line, "", ""];
                 }
-                format!(
-                    "{} {}",
+                [
                     &indent,
+                    " ",
                     line.trim_start_matches(|c| c == ' ' || c == '\t'),
-                )
+                ]
             })
-            .join("\n")
+            .intersperse(["\n", "", ""])
+            .flatten()
+            .collect()
     }
 
     fn format_reserved_word<'t>(&self, token: &'t str) -> Cow<'t, str> {
@@ -257,7 +258,8 @@ impl<'a> Formatter<'a> {
         token
             .split(char::is_whitespace)
             .filter(|s| !s.is_empty())
-            .join(" ")
+            .intersperse(" ")
+            .collect()
     }
 
     fn previous_token(&self) -> Option<&Token<'_>> {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -223,6 +223,8 @@ impl<'a> Formatter<'a> {
     }
 
     fn indent_comment(&self, token: &str) -> String {
+        let indent = self.indentation.get_indent();
+
         token
             .split('\n')
             .enumerate()
@@ -235,10 +237,8 @@ impl<'a> Formatter<'a> {
                 }
                 format!(
                     "{} {}",
-                    self.indentation.get_indent(),
-                    line.chars()
-                        .skip_while(|&c| c == ' ' || c == '\t')
-                        .collect::<String>()
+                    &indent,
+                    line.trim_start_matches(|c| c == ' ' || c == '\t'),
                 )
             })
             .join("\n")


### PR DESCRIPTION
Hello, I took a look at sqlformat-rs after seeing your comment in the sqlx issue and noticed that starting from Rust 1.56 it will be possible to drop the dependency on itertools, since `.join("something")` can easily be implemented with `.intersperse("something").collect()` thanks to the newly stabilized [Intersperse api](https://doc.rust-lang.org/nightly/std/iter/trait.Iterator.html#method.intersperse).

Feel free to leave this PR sitting until it makes sense to bump the MSRV to 1.56

