### PR TITLE
Fix string escaping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,9 +647,12 @@ mod tests {
     #[test]
     fn it_recognizes_escaped_strings() {
         let inputs = [
-            "\"foo \\\" JOIN bar\"",
-            "'foo \\' JOIN bar'",
-            "`foo `` JOIN bar`",
+            r#""foo \" JOIN bar""#,
+            r#"'foo \' JOIN bar'"#,
+            r#"`foo `` JOIN bar`"#,
+            r#"'foo '' JOIN bar'"#,
+            r#"'two households"'"#,
+            r#"'two households'''"#,
         ];
         let options = FormatOptions::default();
         for input in &inputs {


### PR DESCRIPTION
The is a bug in string escaping code. 

Reproduction:
```rust
fn main() {
    use sqlformat::*;

    let res = format("''some text ending with escaped quote''", &QueryParams::None, FormatOptions::default());
    println!("{res}");
}
```
prints:
```
' some text ending with escaped quote ' ''
```
but should print:
```
'some text ending with escaped quote'''
```

It's a small bug in `tokenizer::take_till_escaping`, which I fixed and added a test to cover this case.