### PR TITLE
treat $$ as a reserved token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1415,4 +1415,23 @@ mod tests {
 
         assert_eq!(format(input, &QueryParams::None, options), expected);
     }
+
+    #[test]
+    fn it_keeps_double_dollar_signs_together() {
+        let input = "CREATE FUNCTION abc() AS $$ SELECT * FROM table $$ LANGUAGE plpgsql;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE FUNCTION abc() AS
+            $$
+            SELECT
+              *
+            FROM
+              table
+            $$
+            LANGUAGE plpgsql;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -533,6 +533,7 @@ fn get_top_level_reserved_token_no_indent(input: &str) -> IResult<&str, Token<'_
         terminated(tag("MINUS"), end_of_word),
         terminated(tag("UNION"), end_of_word),
         terminated(tag("UNION ALL"), end_of_word),
+        terminated(tag("$$"), end_of_word),
     ))(&uc_input);
     if let Ok((_, token)) = result {
         let final_word = token.split(' ').last().unwrap();


### PR DESCRIPTION
Fixes #20. 

The output from the example in that issue is now

```sql
CREATE
OR REPLACE FUNCTION generate_ulid() RETURNS uuid AS
$$
SELECT
  (
    lpad(
      to_hex(
        floor(
          extract(
            epoch
            FROM
              clock_timestamp()
          ) * 1000
        ) :: bigint
      ),
      12,
      '0'
    ) || encode(gen_random_bytes(10), 'hex')
  ) :: uuid;

$$
LANGUAGE SQL;
```

I think the `::` should not have spaces around it but that can wait for another PR. For now, this allows Postgres to parse it properly.