### PR TITLE
Format "begin" and "declare" for plpgsql

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1415,4 +1415,23 @@ mod tests {
 
         assert_eq!(format(input, &QueryParams::None, options), expected);
     }
+
+    #[test]
+    fn it_keeps_double_dollar_signs_together() {
+        let input = "CREATE FUNCTION abc() AS $$ SELECT * FROM table $$ LANGUAGE plpgsql;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE FUNCTION abc() AS
+            $$
+            SELECT
+              *
+            FROM
+              table
+            $$
+            LANGUAGE plpgsql;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1434,4 +1434,27 @@ mod tests {
 
         assert_eq!(format(input, &QueryParams::None, options), expected);
     }
+
+    #[test]
+    fn it_formats_pgplsql() {
+        let input = "CREATE FUNCTION abc() AS $$ DECLARE a int := 1; b int := 2; BEGIN SELECT * FROM table $$ LANGUAGE plpgsql;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE FUNCTION abc() AS
+            $$
+            DECLARE
+            a int := 1;
+            b int := 2;
+            BEGIN
+            SELECT
+              *
+            FROM
+              table
+            $$
+            LANGUAGE plpgsql;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -528,6 +528,8 @@ fn get_newline_reserved_token<'a>(
 fn get_top_level_reserved_token_no_indent(input: &str) -> IResult<&str, Token<'_>> {
     let uc_input = get_uc_words(input, 2);
     let result: IResult<&str, &str> = alt((
+        terminated(tag("BEGIN"), end_of_word),
+        terminated(tag("DECLARE"), end_of_word),
         terminated(tag("INTERSECT"), end_of_word),
         terminated(tag("INTERSECT ALL"), end_of_word),
         terminated(tag("MINUS"), end_of_word),
@@ -569,7 +571,6 @@ fn get_plain_reserved_token(input: &str) -> IResult<&str, Token<'_>> {
         terminated(tag("AUTOCOMMIT"), end_of_word),
         terminated(tag("AUTO_INCREMENT"), end_of_word),
         terminated(tag("BACKUP"), end_of_word),
-        terminated(tag("BEGIN"), end_of_word),
         terminated(tag("BETWEEN"), end_of_word),
         terminated(tag("BINLOG"), end_of_word),
         terminated(tag("BOTH"), end_of_word),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -533,6 +533,7 @@ fn get_top_level_reserved_token_no_indent(input: &str) -> IResult<&str, Token<'_
         terminated(tag("MINUS"), end_of_word),
         terminated(tag("UNION"), end_of_word),
         terminated(tag("UNION ALL"), end_of_word),
+        terminated(tag("$$"), end_of_word),
     ))(&uc_input);
     if let Ok((_, token)) = result {
         let final_word = token.split(' ').last().unwrap();


### PR DESCRIPTION
This builds on #29.

Format `DECLARE` and `BEGIN` on their own lines so that Postgres functions look better.

Reference: https://www.postgresql.org/docs/current/plpgsql-structure.html