### PR TITLE
Allow scientific notation without + or - as these are optional.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1401,13 +1401,14 @@ mod tests {
 
     #[test]
     fn it_recognizes_scientific_notation() {
-        let input = "SELECT *, 1e-7 as small, 1e+7 as large FROM t";
+        let input = "SELECT *, 1e-7 as small, 1e2 as medium, 1e+7 as large FROM t";
         let options = FormatOptions::default();
         let expected = indoc!(
             "
             SELECT
               *,
               1e-7 as small,
+              1e2 as medium,
               1e+7 as large
             FROM
               t"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -393,7 +393,7 @@ fn scientific_notation(input: &str) -> IResult<&str, &str> {
     recognize(tuple((
         alt((decimal_number, digit1)),
         tag("e"),
-        alt((tag("-"), tag("+"))),
+        alt((tag("-"), tag("+"), tag(""))),
         digit1,
     )))(input)
 }


### PR DESCRIPTION
1e16 and 1e+16 are both valid.

Attempts to fix https://github.com/shssoichiro/sqlformat-rs/issues/22