### PR TITLE
Allow alphanumeric characters in SQLLite style parameters.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["sql"]
 categories = ["development-tools"]
 
 [dependencies]
-itertools = "0.11"
+itertools = "0.12"
 nom = "7.0.0"
 unicode_categories = "0.1.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,6 +1068,21 @@ mod tests {
     }
 
     #[test]
+    fn it_recognizes_dollar_sign_alphanumeric_placeholders() {
+        let input = "SELECT $hash, $foo, $bar;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            SELECT
+              $hash,
+              $foo,
+              $bar;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
+
+    #[test]
     fn it_recognizes_dollar_sign_numbered_placeholders_with_param_values() {
         let input = "SELECT $2, $3, $1;";
         let params = vec![
@@ -1086,6 +1101,28 @@ mod tests {
 
         assert_eq!(
             format(input, &QueryParams::Indexed(params), options),
+            expected
+        );
+    }
+
+    #[test]
+    fn it_recognizes_dollar_sign_alphanumeric_placeholders_with_param_values() {
+        let input =
+            "SELECT $hash, $salt;";
+        let params = vec![
+            ("hash".to_string(), "hash value".to_string()),
+            ("salt".to_string(), "salt value".to_string()),
+        ];
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            SELECT
+              hash value,
+              salt value;"
+        );
+
+        assert_eq!(
+            format(input, &QueryParams::Named(params), options),
             expected
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1401,13 +1401,14 @@ mod tests {
 
     #[test]
     fn it_recognizes_scientific_notation() {
-        let input = "SELECT *, 1e-7 as small, 1e+7 as large FROM t";
+        let input = "SELECT *, 1e-7 as small, 1e2 as medium, 1e+7 as large FROM t";
         let options = FormatOptions::default();
         let expected = indoc!(
             "
             SELECT
               *,
               1e-7 as small,
+              1e2 as medium,
               1e+7 as large
             FROM
               t"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@ mod tokenizer;
 /// Formats whitespace in a SQL string to make it easier to read.
 /// Optionally replaces parameter placeholders with `params`.
 pub fn format(query: &str, params: &QueryParams, options: FormatOptions) -> String {
-    let named_parameters = matches!(params, QueryParams::Named(_));
+    let named_placeholders = matches!(params, QueryParams::Named(_));
 
-    let tokens = tokenizer::tokenize(query, named_parameters);
+    let tokens = tokenizer::tokenize(query, named_placeholders);
     formatter::format(&tokens, params, options)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1415,4 +1415,23 @@ mod tests {
 
         assert_eq!(format(input, &QueryParams::None, options), expected);
     }
+
+    #[test]
+    fn it_keeps_double_dollar_signs_together() {
+        let input = "CREATE FUNCTION abc() AS $$ SELECT * FROM table $$ LANGUAGE plpgsql;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE FUNCTION abc() AS
+            $$
+            SELECT
+              *
+            FROM
+              table
+            $$
+            LANGUAGE plpgsql;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1435,4 +1435,27 @@ mod tests {
 
         assert_eq!(format(input, &QueryParams::None, options), expected);
     }
+
+    #[test]
+    fn it_formats_pgplsql() {
+        let input = "CREATE FUNCTION abc() AS $$ DECLARE a int := 1; b int := 2; BEGIN SELECT * FROM table $$ LANGUAGE plpgsql;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE FUNCTION abc() AS
+            $$
+            DECLARE
+            a int := 1;
+            b int := 2;
+            BEGIN
+            SELECT
+              *
+            FROM
+              table
+            $$
+            LANGUAGE plpgsql;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, options), expected);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1113,8 +1113,7 @@ mod tests {
 
     #[test]
     fn it_recognizes_dollar_sign_alphanumeric_placeholders_with_param_values() {
-        let input =
-            "SELECT $hash, $salt, $1, $2;";
+        let input = "SELECT $hash, $salt, $1, $2;";
         let params = vec![
             ("hash".to_string(), "hash value".to_string()),
             ("salt".to_string(), "salt value".to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ mod tokenizer;
 /// Formats whitespace in a SQL string to make it easier to read.
 /// Optionally replaces parameter placeholders with `params`.
 pub fn format(query: &str, params: &QueryParams, options: FormatOptions) -> String {
-    let tokens = tokenizer::tokenize(query, params);
+    let named_parameters = matches!(params, QueryParams::Named(_));
+
+    let tokens = tokenizer::tokenize(query, named_parameters);
     formatter::format(&tokens, params, options)
 }
 
@@ -1098,9 +1100,9 @@ mod tests {
               second,
               third,
               first,
-              $ named,
+              $named,
               4th,
-              $ alias;"
+              $alias;"
         );
 
         assert_eq!(

--- a/src/params.rs
+++ b/src/params.rs
@@ -12,7 +12,7 @@ impl<'a> Params<'a> {
     }
 
     pub fn get(&mut self, token: &'a Token<'a>) -> &'a str {
-        let named_parameter_token = token.key.as_ref().map_or(false, |key| key.named() != "");
+        let named_placeholder_token = token.key.as_ref().map_or(false, |key| key.named() != "");
 
         match self.params {
             QueryParams::Named(params) => token
@@ -25,7 +25,7 @@ impl<'a> Params<'a> {
                         .map(|param| param.1.as_str())
                 })
                 .unwrap_or(token.value),
-            QueryParams::Indexed(params) if named_parameter_token == false => {
+            QueryParams::Indexed(params) if named_placeholder_token == false => {
                 if let Some(key) = token.key.as_ref().and_then(|key| key.indexed()) {
                     params
                         .get(key)

--- a/src/params.rs
+++ b/src/params.rs
@@ -25,7 +25,7 @@ impl<'a> Params<'a> {
                         .map(|param| param.1.as_str())
                 })
                 .unwrap_or(token.value),
-            QueryParams::Indexed(params) if named_placeholder_token == false => {
+            QueryParams::Indexed(params) if !named_placeholder_token => {
                 if let Some(key) = token.key.as_ref().and_then(|key| key.indexed()) {
                     params
                         .get(key)
@@ -40,7 +40,7 @@ impl<'a> Params<'a> {
                     value
                 }
             }
-            QueryParams::None | _ => token.value,
+            _ => token.value,
         }
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -39,7 +39,7 @@ impl<'a> Params<'a> {
                     self.index += 1;
                     value
                 }
-            },
+            }
             QueryParams::None | _ => token.value,
         }
     }

--- a/src/params.rs
+++ b/src/params.rs
@@ -12,6 +12,8 @@ impl<'a> Params<'a> {
     }
 
     pub fn get(&mut self, token: &'a Token<'a>) -> &'a str {
+        let named_parameter_token = token.key.as_ref().map_or(false, |key| key.named() != "");
+
         match self.params {
             QueryParams::Named(params) => token
                 .key
@@ -23,7 +25,7 @@ impl<'a> Params<'a> {
                         .map(|param| param.1.as_str())
                 })
                 .unwrap_or(token.value),
-            QueryParams::Indexed(params) => {
+            QueryParams::Indexed(params) if named_parameter_token == false => {
                 if let Some(key) = token.key.as_ref().and_then(|key| key.indexed()) {
                     params
                         .get(key)
@@ -37,8 +39,8 @@ impl<'a> Params<'a> {
                     self.index += 1;
                     value
                 }
-            }
-            QueryParams::None => token.value,
+            },
+            QueryParams::None | _ => token.value,
         }
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -393,7 +393,7 @@ fn scientific_notation(input: &str) -> IResult<&str, &str> {
     recognize(tuple((
         alt((decimal_number, digit1)),
         tag("e"),
-        alt((tag("-"), tag("+"))),
+        alt((tag("-"), tag("+"), tag(""))),
         digit1,
     )))(input)
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -528,6 +528,8 @@ fn get_newline_reserved_token<'a>(
 fn get_top_level_reserved_token_no_indent(input: &str) -> IResult<&str, Token<'_>> {
     let uc_input = get_uc_words(input, 2);
     let result: IResult<&str, &str> = alt((
+        terminated(tag("BEGIN"), end_of_word),
+        terminated(tag("DECLARE"), end_of_word),
         terminated(tag("INTERSECT"), end_of_word),
         terminated(tag("INTERSECT ALL"), end_of_word),
         terminated(tag("MINUS"), end_of_word),
@@ -569,7 +571,6 @@ fn get_plain_reserved_token(input: &str) -> IResult<&str, Token<'_>> {
         terminated(tag("AUTOCOMMIT"), end_of_word),
         terminated(tag("AUTO_INCREMENT"), end_of_word),
         terminated(tag("BACKUP"), end_of_word),
-        terminated(tag("BEGIN"), end_of_word),
         terminated(tag("BETWEEN"), end_of_word),
         terminated(tag("BINLOG"), end_of_word),
         terminated(tag("BOTH"), end_of_word),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -290,9 +290,9 @@ fn get_close_paren_token(input: &str) -> IResult<&str, Token<'_>> {
 
 fn get_placeholder_token(input: &str) -> IResult<&str, Token<'_>> {
     alt((
-        get_ident_named_placeholder_token,
-        get_string_named_placeholder_token,
         get_indexed_placeholder_token,
+        get_ident_named_placeholder_token,
+        get_string_named_placeholder_token
     ))(input)
 }
 
@@ -327,7 +327,7 @@ fn get_indexed_placeholder_token(input: &str) -> IResult<&str, Token<'_>> {
 
 fn get_ident_named_placeholder_token(input: &str) -> IResult<&str, Token<'_>> {
     recognize(tuple((
-        alt((char('@'), char(':'))),
+        alt((char('@'), char(':'), char('$'))),
         take_while1(|item: char| {
             item.is_alphanumeric() || item == '.' || item == '_' || item == '$'
         }),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -16,9 +16,12 @@ pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'
     let mut last_reserved_token = None;
 
     // Keep processing the string until it is empty
-    while let Ok(result) =
-        get_next_token(input, tokens.last().cloned(), last_reserved_token.clone(), named_placeholders)
-    {
+    while let Ok(result) = get_next_token(
+        input,
+        tokens.last().cloned(),
+        last_reserved_token.clone(),
+        named_placeholders,
+    ) {
         if result.1.kind == TokenKind::Reserved {
             last_reserved_token = Some(result.1.clone());
         }
@@ -83,7 +86,7 @@ fn get_next_token<'a>(
     input: &'a str,
     previous_token: Option<Token<'a>>,
     last_reserved_token: Option<Token<'a>>,
-    named_placeholders: bool
+    named_placeholders: bool,
 ) -> IResult<&'a str, Token<'a>> {
     get_whitespace_token(input)
         .or_else(|_| get_comment_token(input))
@@ -297,13 +300,13 @@ fn get_placeholder_token(input: &str, named_placeholders: bool) -> IResult<&str,
         alt((
             get_ident_named_placeholder_token,
             get_string_named_placeholder_token,
-            get_indexed_placeholder_token
+            get_indexed_placeholder_token,
         ))(input)
     } else {
         alt((
             get_indexed_placeholder_token,
             get_ident_named_placeholder_token,
-            get_string_named_placeholder_token
+            get_string_named_placeholder_token,
         ))(input)
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -10,14 +10,14 @@ use nom::{AsChar, Err, IResult};
 use std::borrow::Cow;
 use unicode_categories::UnicodeCategories;
 
-pub(crate) fn tokenize(mut input: &str, named_parameters: bool) -> Vec<Token<'_>> {
+pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'_>> {
     let mut tokens: Vec<Token> = Vec::new();
 
     let mut last_reserved_token = None;
 
     // Keep processing the string until it is empty
     while let Ok(result) =
-        get_next_token(input, tokens.last().cloned(), last_reserved_token.clone(), named_parameters)
+        get_next_token(input, tokens.last().cloned(), last_reserved_token.clone(), named_placeholders)
     {
         if result.1.kind == TokenKind::Reserved {
             last_reserved_token = Some(result.1.clone());
@@ -83,14 +83,14 @@ fn get_next_token<'a>(
     input: &'a str,
     previous_token: Option<Token<'a>>,
     last_reserved_token: Option<Token<'a>>,
-    named_parameters: bool
+    named_placeholders: bool
 ) -> IResult<&'a str, Token<'a>> {
     get_whitespace_token(input)
         .or_else(|_| get_comment_token(input))
         .or_else(|_| get_string_token(input))
         .or_else(|_| get_open_paren_token(input))
         .or_else(|_| get_close_paren_token(input))
-        .or_else(|_| get_placeholder_token(input, named_parameters))
+        .or_else(|_| get_placeholder_token(input, named_placeholders))
         .or_else(|_| get_number_token(input))
         .or_else(|_| get_reserved_word_token(input, previous_token, last_reserved_token))
         .or_else(|_| get_word_token(input))
@@ -289,11 +289,11 @@ fn get_close_paren_token(input: &str) -> IResult<&str, Token<'_>> {
     })
 }
 
-fn get_placeholder_token(input: &str, named_parameters: bool) -> IResult<&str, Token<'_>> {
-    // The precedence changes based on 'named_parameters' but not the exhaustiveness.
+fn get_placeholder_token(input: &str, named_placeholders: bool) -> IResult<&str, Token<'_>> {
+    // The precedence changes based on 'named_placeholders' but not the exhaustiveness.
     // This is to ensure the formatting is the same even if parameters aren't used.
 
-    if named_parameters {
+    if named_placeholders {
         alt((
             get_ident_named_placeholder_token,
             get_string_named_placeholder_token,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -533,6 +533,7 @@ fn get_top_level_reserved_token_no_indent(input: &str) -> IResult<&str, Token<'_
         terminated(tag("MINUS"), end_of_word),
         terminated(tag("UNION"), end_of_word),
         terminated(tag("UNION ALL"), end_of_word),
+        terminated(tag("$$"), end_of_word),
     ))(&uc_input);
     if let Ok((_, token)) = result {
         let final_word = token.split(' ').last().unwrap();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -93,9 +93,9 @@ fn get_next_token<'a>(
         .or_else(|_| get_string_token(input))
         .or_else(|_| get_open_paren_token(input))
         .or_else(|_| get_close_paren_token(input))
-        .or_else(|_| get_placeholder_token(input, named_placeholders))
         .or_else(|_| get_number_token(input))
         .or_else(|_| get_reserved_word_token(input, previous_token, last_reserved_token))
+        .or_else(|_| get_placeholder_token(input, named_placeholders))
         .or_else(|_| get_word_token(input))
         .or_else(|_| get_operator_token(input))
 }


### PR DESCRIPTION
- I've made "$" a valid identifier in get_ident_named_placeholder_token().
- Added some tests mixing indexed and named parameters.
- Adjusting the parameter precedence based on the initial QueryParams provided. (Named vs Indexed).
- The first commit https://github.com/shssoichiro/sqlformat-rs/commit/766c92316d77ba18f66c65b57b52838fadf67d03 was sufficient to get to where I wanted to get, the rest just addresses mixed parameter types which might not actually be a real issue anyway...

Attempts to fix https://github.com/shssoichiro/sqlformat-rs/issues/18

I don't have a Rust background so there may be better ways of doing this. 

Happy to adjust as necessary or throw out the lot as it may be.

Thanks.