### PR TITLE
fix: temporary value does not live long enough

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -137,11 +137,11 @@ impl<'a> Formatter<'a> {
 
     fn format_with_spaces(&self, token: &Token<'_>, query: &mut String) {
         let value = if token.kind == TokenKind::Reserved {
-            &self.equalize_whitespace(&self.format_reserved_word(token.value))
+            self.equalize_whitespace(&self.format_reserved_word(token.value))
         } else {
-            token.value
+            token.value.to_string()
         };
-        query.push_str(value);
+        query.push_str(&value);
         query.push(' ');
     }
 


### PR DESCRIPTION
In rust 1.63.0 I get an error that the value does not live long enough. The rust-version of this crate state 1.56.0 is that checked and accurate? 

This seems to have been introduced in 0.2.5 as pinning to 0.2.4 I am able to compile on 1.63.0