### PR TITLE
Port to Winnow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["sql"]
 categories = ["development-tools"]
 
 [dependencies]
-nom = "7.0.0"
 unicode_categories = "0.1.1"
+winnow = "0.6.20"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 
 [dependencies]
 unicode_categories = "0.1.1"
-winnow = "0.6.20"
+winnow = { version = "0.6.20", features = ["simd"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -94,25 +94,27 @@ fn get_next_token<'a>(
     last_reserved_top_level_token: Option<Token<'a>>,
     named_placeholders: bool,
 ) -> IResult<&'a str, Token<'a>> {
-    get_whitespace_token(input)
-        .or_else(|_| get_comment_token(input))
-        .or_else(|_| get_string_token(input))
-        .or_else(|_| get_open_paren_token(input))
-        .or_else(|_| get_close_paren_token(input))
-        .or_else(|_| get_number_token(input))
-        .or_else(|_| {
+    alt((
+        get_whitespace_token,
+        get_comment_token,
+        get_string_token,
+        get_open_paren_token,
+        get_close_paren_token,
+        get_number_token,
+        |input| {
             get_reserved_word_token(
                 input,
-                previous_token,
-                last_reserved_token,
-                last_reserved_top_level_token,
+                previous_token.clone(),
+                last_reserved_token.clone(),
+                last_reserved_top_level_token.clone(),
             )
-        })
-        .or_else(|_| get_double_colon_token(input))
-        .or_else(|_| get_operator_token(input))
-        .or_else(|_| get_placeholder_token(input, named_placeholders))
-        .or_else(|_| get_word_token(input))
-        .or_else(|_| get_any_other_char(input))
+        },
+        get_double_colon_token,
+        get_operator_token,
+        |input| get_placeholder_token(input, named_placeholders.clone()),
+        get_word_token,
+        get_any_other_char,
+    ))(input)
 }
 fn get_double_colon_token(input: &str) -> IResult<&str, Token<'_>> {
     tag("::")(input).map(|(input, token)| {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1056,7 +1056,7 @@ fn get_operator_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         .parse_next(input)
 }
 fn get_any_other_char<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
-    any.verify(|&token: &char| token != '\n' && token != '\r')
+    one_of(|token| token != '\n' && token != '\r')
         .take()
         .parse_next(input)
         .map(|token| Token {
@@ -1069,7 +1069,7 @@ fn get_any_other_char<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
 fn end_of_word<'i>(input: &mut &'i str) -> PResult<&'i str> {
     peek(alt((
         eof,
-        take(1usize).verify(|val: &str| !is_word_character(val.chars().next().unwrap())),
+        one_of(|val: char| !is_word_character(val)).take(),
     )))
     .parse_next(input)
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -17,6 +17,10 @@ pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'
     let mut last_reserved_token = None;
     let mut last_reserved_top_level_token = None;
 
+    if let Ok(Some(result)) = opt(get_whitespace_token).parse_next(&mut input) {
+        tokens.push(result);
+    }
+
     // Keep processing the string until it is empty
     while let Ok(result) = get_next_token(
         &mut input,
@@ -32,6 +36,10 @@ pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'
         }
 
         tokens.push(result);
+
+        if let Ok(Some(result)) = opt(get_whitespace_token).parse_next(&mut input) {
+            tokens.push(result);
+        }
     }
     tokens
 }
@@ -95,7 +103,6 @@ fn get_next_token<'a>(
     named_placeholders: bool,
 ) -> PResult<Token<'a>> {
     alt((
-        get_whitespace_token,
         get_comment_token,
         get_string_token,
         get_open_paren_token,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,7 +6,7 @@ use nom::error::ParseError;
 use nom::error::{Error, ErrorKind};
 use nom::multi::{many0, many_m_n};
 use nom::sequence::{terminated, tuple};
-use nom::{AsChar, Err, IResult};
+use nom::{Err, IResult};
 use std::borrow::Cow;
 use unicode_categories::UnicodeCategories;
 
@@ -179,7 +179,7 @@ pub fn take_till_escaping<'a, Error: ParseError<&'a str>>(
     escapes: &'static [char],
 ) -> impl Fn(&'a str) -> IResult<&'a str, &'a str, Error> {
     move |input: &str| {
-        let mut chars = input.chars().enumerate().peekable();
+        let mut chars = input.char_indices().peekable();
         loop {
             let item = chars.next();
             let next = chars.peek().map(|item| item.1);
@@ -193,7 +193,7 @@ pub fn take_till_escaping<'a, Error: ParseError<&'a str>>(
                     }
 
                     if item.1 == desired {
-                        let byte_pos = input.chars().take(item.0).map(|c| c.len()).sum::<usize>();
+                        let byte_pos = item.0;
                         return Ok((&input[byte_pos..], &input[..byte_pos]));
                     }
                 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -217,13 +217,15 @@ fn get_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
 
 // Like above but it doesn't replace double quotes
 fn get_placeholder_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
-    alt((
-        ('`', take_till_escaping('`', &['`']), any).take(),
-        ('[', take_till_escaping(']', &[']']), any).take(),
-        ('"', take_till_escaping('"', &['\\']), any).take(),
-        ('\'', take_till_escaping('\'', &['\\']), any).take(),
-        ("N'", take_till_escaping('\'', &['\\']), any).take(),
-    ))
+    dispatch! {any;
+        '`'=>( take_till_escaping('`', &['`']), any).void(),
+        '['=>( take_till_escaping(']', &[']']), any).void(),
+        '"'=>( take_till_escaping('"', &['\\']), any).void(),
+        '\''=>( take_till_escaping('\'', &['\\']), any).void(),
+        'N' =>('\'', take_till_escaping('\'', &['\\']), any).void(),
+        _ => fail,
+    }
+    .take()
     .parse_next(input)
     .map(|token| Token {
         kind: TokenKind::String,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,7 +7,7 @@ use winnow::error::ErrMode;
 use winnow::error::ErrorKind;
 use winnow::error::ParserError as _;
 use winnow::prelude::*;
-use winnow::stream::Stream as _;
+use winnow::stream::{ContainsToken as _, Stream as _};
 use winnow::token::{any, one_of, take, take_until, take_while};
 use winnow::PResult;
 
@@ -370,6 +370,10 @@ fn get_reserved_word_token<'a>(
         if token.value == "." {
             return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
         }
+    }
+
+    if !('a'..='z', 'A'..='Z', '$').contains_token(input.chars().next().unwrap_or('\0')) {
+        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
     }
 
     alt((

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -184,16 +184,15 @@ pub fn take_till_escaping<'a, Error: ParseError<&'a str>>(
             let item = chars.next();
             let next = chars.peek().map(|item| item.1);
             match item {
-                Some(item) => {
+                Some((byte_pos, item)) => {
                     // escape?
-                    if escapes.contains(&item.1) && next.map(|n| n == desired).unwrap_or(false) {
+                    if escapes.contains(&item) && next.map(|n| n == desired).unwrap_or(false) {
                         // consume this and next char
                         chars.next();
                         continue;
                     }
 
-                    if item.1 == desired {
-                        let byte_pos = item.0;
+                    if item == desired {
                         return Ok((&input[byte_pos..], &input[..byte_pos]));
                     }
                 }


### PR DESCRIPTION
I want to be clear, just because I did this, there is no pressure to adopt it. I did this more out of procrastination than anything and then turned into a personal challenge (as I explain later).  If this PR is not wanted, I can split out any desired clean up or performance improvements independent of Winnow and submit that.

From [v0.1.1 release](https://github.com/shssoichiro/sqlformat-rs/blob/master/CHANGELOG.md#version-012)

> Rewrite the parser in nom, providing significant performance improvements across the board

Since the use of `nom` was for performance reasons, I kept a careful eye on performance.  Each commit lists the performance compared to the previous commit.  There is some noise in my runs, so we can't read too much into small changes.

I was surprised to find that switching to `winnow` was slower, even with the `simd` feature enabled to match `nom`s behavior considering [most of the time its faster](https://epage.github.io/blog/2023/07/winnow-0-5-the-fastest-rust-parser-combinator-library/#numbers).  This also made this PR a personal challenge.  Unfortunately, I've not yet found the root cause.  My best guess is that [some changes in the design](https://docs.rs/winnow/latest/winnow/_topic/why/index.html#design-trade-offs) made `alt` slower.  Usually, this is unnoticeable because there aren't many and usually replaced with `dispatch!`.  Unfortunately, sqlformat heavily relies on `alt`.  So this led to a new personal challenge to see how much I could speed it up.  I feel like there is more that could be done with reserved words but that would require more knowledge of SQL than I have and may require some larger changes that seemed too risky for this PR.

```
     Running benches/bench.rs (target/release/deps/bench-675d7f32b1e36df6)
simple query            time:   [2.7613 µs 2.7767 µs 2.7958 µs]
                        change: [-32.921% -32.230% -31.502%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

complex query           time:   [16.988 µs 17.011 µs 17.038 µs]
                        change: [-23.576% -23.377% -23.162%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

named params            time:   [6.1707 µs 6.1796 µs 6.1902 µs]
                        change: [-33.985% -33.643% -33.255%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

explicit indexed params time:   [5.4545 µs 5.4754 µs 5.5020 µs]
                        change: [-39.756% -39.206% -38.632%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

implicit indexed params time:   [5.6417 µs 5.7211 µs 5.8084 µs]
                        change: [-32.780% -31.956% -31.115%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  15 (15.00%) low severe
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking issue 633: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.2s, enable flat
sampling, or reduce sample count to 60.
issue 633               time:   [1.2792 ms 1.2815 ms 1.2840 ms]
                        change: [-66.075% -65.972% -65.845%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low severe
  4 (4.00%) high mild
  9 (9.00%) high severe

issue 633 query 2       time:   [25.968 µs 26.313 µs 26.652 µs]
                        change: [-23.522% -23.045% -22.565%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

issue 633 query 3       time:   [314.31 µs 317.31 µs 320.90 µs]
                        change: [-72.688% -72.329% -71.959%] (p = 0.00 < 0.05)
                        Performance has improved.

```