### PR TITLE
chore: Upgrade to Winnow 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 
 [dependencies]
 unicode_categories = "0.1.1"
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 
 [dependencies]
 unicode_categories = "0.1.1"
-winnow = { version = "0.6.23", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -3,11 +3,10 @@ use unicode_categories::UnicodeCategories;
 use winnow::ascii::{digit0, digit1, till_line_ending, Caseless};
 use winnow::combinator::{alt, dispatch, eof, fail, opt, peek, terminated};
 use winnow::error::ContextError;
-use winnow::error::ErrMode;
-use winnow::error::ParserError as _;
+use winnow::error::ParserError;
 use winnow::prelude::*;
 use winnow::token::{any, one_of, rest, take, take_until, take_while};
-use winnow::ModalResult;
+use winnow::Result;
 
 pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'_>> {
     let mut tokens: Vec<Token> = Vec::new();
@@ -99,7 +98,7 @@ fn get_next_token<'a>(
     last_reserved_token: Option<Token<'a>>,
     last_reserved_top_level_token: Option<Token<'a>>,
     named_placeholders: bool,
-) -> ModalResult<Token<'a>> {
+) -> Result<Token<'a>> {
     alt((
         get_comment_token,
         get_string_token,
@@ -122,14 +121,14 @@ fn get_next_token<'a>(
     ))
     .parse_next(input)
 }
-fn get_double_colon_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_double_colon_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     "::".parse_next(input).map(|token| Token {
         kind: TokenKind::DoubleColon,
         value: token,
         key: None,
     })
 }
-fn get_whitespace_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_whitespace_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     take_while(1.., char::is_whitespace)
         .parse_next(input)
         .map(|token| Token {
@@ -139,7 +138,7 @@ fn get_whitespace_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn get_comment_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_comment_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     dispatch! {any;
         '#' => till_line_ending.value(TokenKind::LineComment),
         '-' => ('-', till_line_ending).value(TokenKind::LineComment),
@@ -158,7 +157,7 @@ fn get_comment_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
 pub fn take_till_escaping<'a>(
     desired: char,
     escapes: &'static [char],
-) -> impl ModalParser<&'a str, &'a str, ContextError> {
+) -> impl Parser<&'a str, &'a str, ContextError> {
     move |input: &mut &'a str| {
         let mut chars = input.char_indices().peekable();
         loop {
@@ -191,7 +190,7 @@ pub fn take_till_escaping<'a>(
 // 3. double quoted string using "" or \" to escape
 // 4. single quoted string using '' or \' to escape
 // 5. national character quoted string using N'' or N\' to escape
-fn get_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_string_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     dispatch! {any;
         '`' => (take_till_escaping('`', &['`']), any).void(),
         '[' => (take_till_escaping(']', &[']']), any).void(),
@@ -211,7 +210,7 @@ fn get_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
 }
 
 // Like above but it doesn't replace double quotes
-fn get_placeholder_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_placeholder_string_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     dispatch! {any;
         '`'=>( take_till_escaping('`', &['`']), any).void(),
         '['=>( take_till_escaping(']', &[']']), any).void(),
@@ -229,7 +228,7 @@ fn get_placeholder_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i
     })
 }
 
-fn get_open_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_open_paren_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     alt(("(", terminated(Caseless("CASE"), end_of_word)))
         .parse_next(input)
         .map(|token| Token {
@@ -239,7 +238,7 @@ fn get_open_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn get_close_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_close_paren_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     alt((")", terminated(Caseless("END"), end_of_word)))
         .parse_next(input)
         .map(|token| Token {
@@ -249,10 +248,7 @@ fn get_close_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn get_placeholder_token<'i>(
-    input: &mut &'i str,
-    named_placeholders: bool,
-) -> ModalResult<Token<'i>> {
+fn get_placeholder_token<'i>(input: &mut &'i str, named_placeholders: bool) -> Result<Token<'i>> {
     // The precedence changes based on 'named_placeholders' but not the exhaustiveness.
     // This is to ensure the formatting is the same even if parameters aren't used.
 
@@ -273,7 +269,7 @@ fn get_placeholder_token<'i>(
     }
 }
 
-fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     alt(((one_of(('?', '$')), digit1).take(), "?"))
         .parse_next(input)
         .map(|token| Token {
@@ -295,7 +291,7 @@ fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'
         })
 }
 
-fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     (
         one_of(('@', ':', '$')),
         take_while(1.., |item: char| {
@@ -314,7 +310,7 @@ fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Tok
         })
 }
 
-fn get_string_named_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_string_named_placeholder_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     (one_of(('@', ':')), get_placeholder_string_token)
         .take()
         .parse_next(input)
@@ -333,7 +329,7 @@ fn get_escaped_placeholder_key<'a>(key: &'a str, quote_char: &str) -> Cow<'a, st
     Cow::Owned(key.replace(&format!("\\{}", quote_char), quote_char))
 }
 
-fn get_number_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_number_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     (opt("-"), alt((scientific_notation, decimal_number, digit1)))
         .take()
         .parse_next(input)
@@ -344,11 +340,11 @@ fn get_number_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn decimal_number<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+fn decimal_number<'i>(input: &mut &'i str) -> Result<&'i str> {
     (digit1, ".", digit0).take().parse_next(input)
 }
 
-fn scientific_notation<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+fn scientific_notation<'i>(input: &mut &'i str) -> Result<&'i str> {
     (
         alt((decimal_number, digit1)),
         "e",
@@ -364,17 +360,17 @@ fn get_reserved_word_token<'a>(
     previous_token: Option<Token<'a>>,
     last_reserved_token: Option<Token<'a>>,
     last_reserved_top_level_token: Option<Token<'a>>,
-) -> ModalResult<Token<'a>> {
+) -> Result<Token<'a>> {
     // A reserved word cannot be preceded by a "."
     // this makes it so in "my_table.from", "from" is not considered a reserved word
     if let Some(token) = previous_token {
         if token.value == "." {
-            return Err(ErrMode::from_input(input));
+            return Err(ParserError::from_input(input));
         }
     }
 
     if !('a'..='z', 'A'..='Z', '$').contains_token(input.chars().next().unwrap_or('\0')) {
-        return Err(ErrMode::from_input(input));
+        return Err(ParserError::from_input(input));
     }
 
     alt((
@@ -398,7 +394,7 @@ fn get_uc_words(input: &str, words: usize) -> String {
 
 fn get_top_level_reserved_token<'a>(
     last_reserved_top_level_token: Option<Token<'a>>,
-) -> impl ModalParser<&'a str, Token<'a>, ContextError> {
+) -> impl Parser<&'a str, Token<'a>, ContextError> {
     move |input: &mut &'a str| {
         let uc_input: String = get_uc_words(input, 3);
         let mut uc_input = uc_input.as_str();
@@ -407,7 +403,7 @@ fn get_top_level_reserved_token<'a>(
         let first_char = peek(any).parse_next(input)?.to_ascii_uppercase();
 
         // Match keywords based on their first letter
-        let result: ModalResult<&str> = match first_char {
+        let result: Result<&str> = match first_char {
             'A' => alt((
                 terminated("ADD", end_of_word),
                 terminated("AFTER", end_of_word),
@@ -463,7 +459,7 @@ fn get_top_level_reserved_token<'a>(
             'W' => terminated("WHERE", end_of_word).parse_next(&mut uc_input),
 
             // If the first character doesn't match any of our keywords, fail early
-            _ => Err(ErrMode::from_input(&uc_input)),
+            _ => Err(ParserError::from_input(&uc_input)),
         };
 
         if let Ok(token) = result {
@@ -488,14 +484,14 @@ fn get_top_level_reserved_token<'a>(
                 key: None,
             })
         } else {
-            Err(ErrMode::from_input(input))
+            Err(ParserError::from_input(input))
         }
     }
 }
 
 fn get_newline_reserved_token<'a>(
     last_reserved_token: Option<Token<'a>>,
-) -> impl ModalParser<&'a str, Token<'a>, ContextError> {
+) -> impl Parser<&'a str, Token<'a>, ContextError> {
     move |input: &mut &'a str| {
         let uc_input: String = get_uc_words(input, 3);
         let mut uc_input = uc_input.as_str();
@@ -552,9 +548,8 @@ fn get_newline_reserved_token<'a>(
         ));
 
         // Combine all parsers
-        let result: ModalResult<&str> =
-            alt((standard_joins, specific_joins, special_joins, operators))
-                .parse_next(&mut uc_input);
+        let result: Result<&str> = alt((standard_joins, specific_joins, special_joins, operators))
+            .parse_next(&mut uc_input);
 
         if let Ok(token) = result {
             let final_word = token.split(' ').last().unwrap();
@@ -576,16 +571,16 @@ fn get_newline_reserved_token<'a>(
                 key: None,
             })
         } else {
-            Err(ErrMode::from_input(input))
+            Err(ParserError::from_input(input))
         }
     }
 }
 
-fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     let uc_input = get_uc_words(input, 2);
     let mut uc_input = uc_input.as_str();
 
-    let result: ModalResult<&str> = alt((
+    let result: Result<&str> = alt((
         terminated("BEGIN", end_of_word),
         terminated("DECLARE", end_of_word),
         terminated("INTERSECT", end_of_word),
@@ -607,19 +602,19 @@ fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> ModalResul
             key: None,
         })
     } else {
-        Err(ErrMode::from_input(input))
+        Err(ParserError::from_input(input))
     }
 }
-fn get_plain_reserved_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_plain_reserved_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     alt((get_plain_reserved_two_token, get_plain_reserved_one_token)).parse_next(input)
 }
-fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     let uc_input = get_uc_words(input, 1);
     let mut uc_input = uc_input.as_str();
 
     let first_char = peek(any).parse_next(input)?.to_ascii_uppercase();
 
-    let result: ModalResult<&str> = match first_char {
+    let result: Result<&str> = match first_char {
         'A' => alt((
             terminated("ACCESSIBLE", end_of_word),
             terminated("ACTION", end_of_word),
@@ -994,7 +989,7 @@ fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i
 
         'Y' => alt((terminated("YEAR_MONTH", end_of_word),)).parse_next(&mut uc_input),
         // If the first character doesn't match any of our keywords, fail early
-        _ => Err(ErrMode::from_input(&uc_input)),
+        _ => Err(ParserError::from_input(&uc_input)),
     };
     if let Ok(token) = result {
         let input_end_pos = token.len();
@@ -1005,14 +1000,14 @@ fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i
             key: None,
         })
     } else {
-        Err(ErrMode::from_input(input))
+        Err(ParserError::from_input(input))
     }
 }
 
-fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     let uc_input = get_uc_words(input, 2);
     let mut uc_input = uc_input.as_str();
-    let result: ModalResult<&str> = alt((
+    let result: Result<&str> = alt((
         terminated("CHARACTER SET", end_of_word),
         terminated("ON DELETE", end_of_word),
         terminated("ON UPDATE", end_of_word),
@@ -1028,11 +1023,11 @@ fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i
             key: None,
         })
     } else {
-        Err(ErrMode::from_input(input))
+        Err(ParserError::from_input(input))
     }
 }
 
-fn get_word_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_word_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     take_while(1.., is_word_character)
         .parse_next(input)
         .map(|token| Token {
@@ -1042,7 +1037,7 @@ fn get_word_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn get_operator_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_operator_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     // Define the allowed operator characters
     let allowed_operators = (
         '!', '<', '>', '=', '|', ':', '-', '~', '*', '&', '@', '^', '?', '#', '/', '%',
@@ -1056,7 +1051,7 @@ fn get_operator_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
         .parse_next(input)
 }
-fn get_any_other_char<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
+fn get_any_other_char<'i>(input: &mut &'i str) -> Result<Token<'i>> {
     one_of(|token| token != '\n' && token != '\r')
         .take()
         .parse_next(input)
@@ -1067,7 +1062,7 @@ fn get_any_other_char<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
         })
 }
 
-fn end_of_word<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
+fn end_of_word<'i>(input: &mut &'i str) -> Result<&'i str> {
     peek(alt((
         eof,
         one_of(|val: char| !is_word_character(val)).take(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -159,7 +159,7 @@ fn get_comment_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
 pub fn take_till_escaping<'a>(
     desired: char,
     escapes: &'static [char],
-) -> impl Parser<&'a str, &'a str, ContextError> {
+) -> impl ModalParser<&'a str, &'a str, ContextError> {
     move |input: &mut &'a str| {
         let mut chars = input.char_indices().peekable();
         loop {
@@ -399,7 +399,7 @@ fn get_uc_words(input: &str, words: usize) -> String {
 
 fn get_top_level_reserved_token<'a>(
     last_reserved_top_level_token: Option<Token<'a>>,
-) -> impl Parser<&'a str, Token<'a>, ContextError> {
+) -> impl ModalParser<&'a str, Token<'a>, ContextError> {
     move |input: &mut &'a str| {
         let uc_input: String = get_uc_words(input, 3);
         let mut uc_input = uc_input.as_str();
@@ -496,7 +496,7 @@ fn get_top_level_reserved_token<'a>(
 
 fn get_newline_reserved_token<'a>(
     last_reserved_token: Option<Token<'a>>,
-) -> impl Parser<&'a str, Token<'a>, ContextError> {
+) -> impl ModalParser<&'a str, Token<'a>, ContextError> {
     move |input: &mut &'a str| {
         let uc_input: String = get_uc_words(input, 3);
         let mut uc_input = uc_input.as_str();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -4,12 +4,11 @@ use winnow::ascii::{digit0, digit1, till_line_ending, Caseless};
 use winnow::combinator::{alt, dispatch, eof, fail, opt, peek, terminated};
 use winnow::error::ContextError;
 use winnow::error::ErrMode;
-use winnow::error::ErrorKind;
 use winnow::error::ParserError as _;
 use winnow::prelude::*;
 use winnow::stream::{ContainsToken as _, Stream as _};
 use winnow::token::{any, one_of, rest, take, take_until, take_while};
-use winnow::PResult;
+use winnow::ModalResult;
 
 pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'_>> {
     let mut tokens: Vec<Token> = Vec::new();
@@ -101,7 +100,7 @@ fn get_next_token<'a>(
     last_reserved_token: Option<Token<'a>>,
     last_reserved_top_level_token: Option<Token<'a>>,
     named_placeholders: bool,
-) -> PResult<Token<'a>> {
+) -> ModalResult<Token<'a>> {
     alt((
         get_comment_token,
         get_string_token,
@@ -124,14 +123,14 @@ fn get_next_token<'a>(
     ))
     .parse_next(input)
 }
-fn get_double_colon_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_double_colon_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     "::".parse_next(input).map(|token| Token {
         kind: TokenKind::DoubleColon,
         value: token,
         key: None,
     })
 }
-fn get_whitespace_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_whitespace_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     take_while(1.., char::is_whitespace)
         .parse_next(input)
         .map(|token| Token {
@@ -141,7 +140,7 @@ fn get_whitespace_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn get_comment_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_comment_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     dispatch! {any;
         '#' => till_line_ending.value(TokenKind::LineComment),
         '-' => ('-', till_line_ending).value(TokenKind::LineComment),
@@ -193,7 +192,7 @@ pub fn take_till_escaping<'a>(
 // 3. double quoted string using "" or \" to escape
 // 4. single quoted string using '' or \' to escape
 // 5. national character quoted string using N'' or N\' to escape
-fn get_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     dispatch! {any;
         '`' => (take_till_escaping('`', &['`']), any).void(),
         '[' => (take_till_escaping(']', &[']']), any).void(),
@@ -213,7 +212,7 @@ fn get_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
 }
 
 // Like above but it doesn't replace double quotes
-fn get_placeholder_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_placeholder_string_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     dispatch! {any;
         '`'=>( take_till_escaping('`', &['`']), any).void(),
         '['=>( take_till_escaping(']', &[']']), any).void(),
@@ -231,7 +230,7 @@ fn get_placeholder_string_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
     })
 }
 
-fn get_open_paren_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_open_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     alt(("(", terminated(Caseless("CASE"), end_of_word)))
         .parse_next(input)
         .map(|token| Token {
@@ -241,7 +240,7 @@ fn get_open_paren_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn get_close_paren_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_close_paren_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     alt((")", terminated(Caseless("END"), end_of_word)))
         .parse_next(input)
         .map(|token| Token {
@@ -251,7 +250,10 @@ fn get_close_paren_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn get_placeholder_token<'i>(input: &mut &'i str, named_placeholders: bool) -> PResult<Token<'i>> {
+fn get_placeholder_token<'i>(
+    input: &mut &'i str,
+    named_placeholders: bool,
+) -> ModalResult<Token<'i>> {
     // The precedence changes based on 'named_placeholders' but not the exhaustiveness.
     // This is to ensure the formatting is the same even if parameters aren't used.
 
@@ -272,7 +274,7 @@ fn get_placeholder_token<'i>(input: &mut &'i str, named_placeholders: bool) -> P
     }
 }
 
-fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     alt(((one_of(('?', '$')), digit1).take(), "?"))
         .parse_next(input)
         .map(|token| Token {
@@ -294,7 +296,7 @@ fn get_indexed_placeholder_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> 
         })
 }
 
-fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     (
         one_of(('@', ':', '$')),
         take_while(1.., |item: char| {
@@ -313,7 +315,7 @@ fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> PResult<Token<'
         })
 }
 
-fn get_string_named_placeholder_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_string_named_placeholder_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     (one_of(('@', ':')), get_placeholder_string_token)
         .take()
         .parse_next(input)
@@ -332,7 +334,7 @@ fn get_escaped_placeholder_key<'a>(key: &'a str, quote_char: &str) -> Cow<'a, st
     Cow::Owned(key.replace(&format!("\\{}", quote_char), quote_char))
 }
 
-fn get_number_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_number_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     (opt("-"), alt((scientific_notation, decimal_number, digit1)))
         .take()
         .parse_next(input)
@@ -343,11 +345,11 @@ fn get_number_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn decimal_number<'i>(input: &mut &'i str) -> PResult<&'i str> {
+fn decimal_number<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
     (digit1, ".", digit0).take().parse_next(input)
 }
 
-fn scientific_notation<'i>(input: &mut &'i str) -> PResult<&'i str> {
+fn scientific_notation<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
     (
         alt((decimal_number, digit1)),
         "e",
@@ -363,17 +365,17 @@ fn get_reserved_word_token<'a>(
     previous_token: Option<Token<'a>>,
     last_reserved_token: Option<Token<'a>>,
     last_reserved_top_level_token: Option<Token<'a>>,
-) -> PResult<Token<'a>> {
+) -> ModalResult<Token<'a>> {
     // A reserved word cannot be preceded by a "."
     // this makes it so in "my_table.from", "from" is not considered a reserved word
     if let Some(token) = previous_token {
         if token.value == "." {
-            return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+            return Err(ErrMode::from_input(input));
         }
     }
 
     if !('a'..='z', 'A'..='Z', '$').contains_token(input.chars().next().unwrap_or('\0')) {
-        return Err(ErrMode::from_error_kind(input, ErrorKind::Slice));
+        return Err(ErrMode::from_input(input));
     }
 
     alt((
@@ -406,7 +408,7 @@ fn get_top_level_reserved_token<'a>(
         let first_char = peek(any).parse_next(input)?.to_ascii_uppercase();
 
         // Match keywords based on their first letter
-        let result: PResult<&str> = match first_char {
+        let result: ModalResult<&str> = match first_char {
             'A' => alt((
                 terminated("ADD", end_of_word),
                 terminated("AFTER", end_of_word),
@@ -462,10 +464,7 @@ fn get_top_level_reserved_token<'a>(
             'W' => terminated("WHERE", end_of_word).parse_next(&mut uc_input),
 
             // If the first character doesn't match any of our keywords, fail early
-            _ => Err(ErrMode::from_error_kind(
-                &uc_input,
-                winnow::error::ErrorKind::Tag,
-            )),
+            _ => Err(ErrMode::from_input(&uc_input)),
         };
 
         if let Ok(token) = result {
@@ -490,7 +489,7 @@ fn get_top_level_reserved_token<'a>(
                 key: None,
             })
         } else {
-            Err(ErrMode::from_error_kind(input, ErrorKind::Tag))
+            Err(ErrMode::from_input(input))
         }
     }
 }
@@ -554,8 +553,9 @@ fn get_newline_reserved_token<'a>(
         ));
 
         // Combine all parsers
-        let result: PResult<&str> = alt((standard_joins, specific_joins, special_joins, operators))
-            .parse_next(&mut uc_input);
+        let result: ModalResult<&str> =
+            alt((standard_joins, specific_joins, special_joins, operators))
+                .parse_next(&mut uc_input);
 
         if let Ok(token) = result {
             let final_word = token.split(' ').last().unwrap();
@@ -577,16 +577,16 @@ fn get_newline_reserved_token<'a>(
                 key: None,
             })
         } else {
-            Err(ErrMode::from_error_kind(input, ErrorKind::Alt))
+            Err(ErrMode::from_input(input))
         }
     }
 }
 
-fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     let uc_input = get_uc_words(input, 2);
     let mut uc_input = uc_input.as_str();
 
-    let result: PResult<&str> = alt((
+    let result: ModalResult<&str> = alt((
         terminated("BEGIN", end_of_word),
         terminated("DECLARE", end_of_word),
         terminated("INTERSECT", end_of_word),
@@ -608,19 +608,19 @@ fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> PResult<To
             key: None,
         })
     } else {
-        Err(ErrMode::from_error_kind(input, ErrorKind::Alt))
+        Err(ErrMode::from_input(input))
     }
 }
-fn get_plain_reserved_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_plain_reserved_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     alt((get_plain_reserved_two_token, get_plain_reserved_one_token)).parse_next(input)
 }
-fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     let uc_input = get_uc_words(input, 1);
     let mut uc_input = uc_input.as_str();
 
     let first_char = peek(any).parse_next(input)?.to_ascii_uppercase();
 
-    let result: PResult<&str> = match first_char {
+    let result: ModalResult<&str> = match first_char {
         'A' => alt((
             terminated("ACCESSIBLE", end_of_word),
             terminated("ACTION", end_of_word),
@@ -995,10 +995,7 @@ fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
 
         'Y' => alt((terminated("YEAR_MONTH", end_of_word),)).parse_next(&mut uc_input),
         // If the first character doesn't match any of our keywords, fail early
-        _ => Err(ErrMode::from_error_kind(
-            &uc_input,
-            winnow::error::ErrorKind::Tag,
-        )),
+        _ => Err(ErrMode::from_input(&uc_input)),
     };
     if let Ok(token) = result {
         let input_end_pos = token.len();
@@ -1009,14 +1006,14 @@ fn get_plain_reserved_one_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
             key: None,
         })
     } else {
-        Err(ErrMode::from_error_kind(input, ErrorKind::Alt))
+        Err(ErrMode::from_input(input))
     }
 }
 
-fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     let uc_input = get_uc_words(input, 2);
     let mut uc_input = uc_input.as_str();
-    let result: PResult<&str> = alt((
+    let result: ModalResult<&str> = alt((
         terminated("CHARACTER SET", end_of_word),
         terminated("ON DELETE", end_of_word),
         terminated("ON UPDATE", end_of_word),
@@ -1032,11 +1029,11 @@ fn get_plain_reserved_two_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
             key: None,
         })
     } else {
-        Err(ErrMode::from_error_kind(input, ErrorKind::Alt))
+        Err(ErrMode::from_input(input))
     }
 }
 
-fn get_word_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_word_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     take_while(1.., is_word_character)
         .parse_next(input)
         .map(|token| Token {
@@ -1046,7 +1043,7 @@ fn get_word_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn get_operator_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_operator_token<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     // Define the allowed operator characters
     let allowed_operators = (
         '!', '<', '>', '=', '|', ':', '-', '~', '*', '&', '@', '^', '?', '#', '/', '%',
@@ -1060,7 +1057,7 @@ fn get_operator_token<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
         .parse_next(input)
 }
-fn get_any_other_char<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
+fn get_any_other_char<'i>(input: &mut &'i str) -> ModalResult<Token<'i>> {
     one_of(|token| token != '\n' && token != '\r')
         .take()
         .parse_next(input)
@@ -1071,7 +1068,7 @@ fn get_any_other_char<'i>(input: &mut &'i str) -> PResult<Token<'i>> {
         })
 }
 
-fn end_of_word<'i>(input: &mut &'i str) -> PResult<&'i str> {
+fn end_of_word<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
     peek(alt((
         eof,
         one_of(|val: char| !is_word_character(val)).take(),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,7 +6,6 @@ use winnow::error::ContextError;
 use winnow::error::ErrMode;
 use winnow::error::ParserError as _;
 use winnow::prelude::*;
-use winnow::stream::{ContainsToken as _, Stream as _};
 use winnow::token::{any, one_of, rest, take, take_until, take_while};
 use winnow::ModalResult;
 


### PR DESCRIPTION
```
     Running benches/bench.rs (target/release/deps/bench-15db45057a99e718)
simple query            time:   [3.3353 µs 3.3459 µs 3.3588 µs]
                        change: [+1.7491% +2.9980% +4.2079%] (p = 0.00 < 0.05)
                        Performance has regressed.

complex query           time:   [16.054 µs 16.086 µs 16.114 µs]
                        change: [-10.142% -9.1919% -8.2558%] (p = 0.00 < 0.05)
                        Performance has improved.

named params            time:   [6.1227 µs 6.1298 µs 6.1380 µs]
                        change: [-1.6477% -1.2976% -0.9061%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

explicit indexed params time:   [6.0797 µs 6.0869 µs 6.0943 µs]
                        change: [-8.1424% -7.8433% -7.5629%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

implicit indexed params time:   [6.2304 µs 6.3209 µs 6.4045 µs]
                        change: [-7.2099% -6.4820% -5.7399%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high severe

Benchmarking issue 633: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.9s, enable flat sampling, o
r reduce sample count to 50.
issue 633               time:   [1.3793 ms 1.3822 ms 1.3852 ms]
                        change: [-10.047% -8.8762% -7.6311%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  4 (4.00%) high severe

issue 633 query 2       time:   [27.811 µs 27.859 µs 27.907 µs]
                        change: [+0.6538% +0.9371% +1.2402%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild

issue 633 query 3       time:   [401.95 µs 402.46 µs 402.99 µs]
                        change: [-5.3602% -4.5306% -3.6213%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```