### PR TITLE
Improve the inline/columnar combination

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -4,7 +4,7 @@ use crate::indentation::Indentation;
 use crate::inline_block::InlineBlock;
 use crate::params::Params;
 use crate::tokenizer::{Token, TokenKind};
-use crate::{FormatOptions, QueryParams};
+use crate::{FormatOptions, QueryParams, SpanInfo};
 
 // -- fmt: off
 // -- fmt: on
@@ -167,14 +167,8 @@ impl<'a> Formatter<'a> {
             indentation: Indentation::new(options),
             inline_block: InlineBlock::new(
                 options.max_inline_block,
-                match (options.max_inline_arguments, options.max_inline_top_level) {
-                    (Some(max_inline_args), Some(max_inline_top)) => {
-                        max_inline_args.min(max_inline_top)
-                    }
-                    (Some(max_inline_args), None) => max_inline_args,
-                    (None, Some(max_inline_top)) => max_inline_top,
-                    (None, None) => 0,
-                },
+                options.max_inline_arguments.unwrap_or(0),
+                options.max_inline_top_level.unwrap_or(0),
             ),
             block_level: 0,
         }
@@ -215,12 +209,12 @@ impl<'a> Formatter<'a> {
         self.add_new_line(query);
     }
 
-    // if we are inside an inline block we decide our behaviour as if we are an inline argument
-    fn top_level_behavior(&self) -> (bool, bool) {
-        let span_len = self.top_level_tokens_span();
+    // if we are inside an inline block we decide our behaviour as if were inline
+    fn top_level_behavior(&self, span_info: &SpanInfo) -> (bool, bool) {
+        let span_len = span_info.full_span;
         let block_len = self.inline_block.cur_len();
         if block_len > 0 {
-            let limit = self.options.max_inline_arguments.unwrap_or(0);
+            let limit = self.options.max_inline_top_level.unwrap_or(0);
             (limit < block_len, limit < span_len)
         } else {
             (
@@ -233,8 +227,8 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_top_level_reserved_word(&mut self, token: &Token<'_>, query: &mut String) {
-        let span_len = self.top_level_tokens_span();
-        let (newline_before, newline_after) = self.top_level_behavior();
+        let span_info = self.top_level_tokens_info();
+        let (newline_before, newline_after) = self.top_level_behavior(&span_info);
 
         if newline_before {
             self.indentation.decrease_top_level();
@@ -242,7 +236,7 @@ impl<'a> Formatter<'a> {
         }
         query.push_str(&self.equalize_whitespace(&self.format_reserved_word(token.value)));
         if newline_after {
-            self.indentation.increase_top_level(span_len);
+            self.indentation.increase_top_level(span_info);
             self.add_new_line(query);
         } else {
             query.push(' ');
@@ -250,7 +244,8 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_top_level_reserved_word_no_indent(&mut self, token: &Token<'_>, query: &mut String) {
-        let (newline_before, newline_after) = self.top_level_behavior();
+        let span_info = self.top_level_tokens_info();
+        let (newline_before, newline_after) = self.top_level_behavior(&span_info);
 
         if newline_before {
             self.indentation.decrease_top_level();
@@ -263,10 +258,11 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_newline_reserved_word(&mut self, token: &Token<'_>, query: &mut String) {
-        if self
-            .options
-            .max_inline_arguments
-            .map_or(true, |limit| limit < self.indentation.top_level_span())
+        if !self.inline_block.is_active()
+            && self
+                .options
+                .max_inline_arguments
+                .map_or(true, |limit| limit < self.indentation.span())
         {
             self.add_new_line(query);
         } else {
@@ -406,7 +402,7 @@ impl<'a> Formatter<'a> {
 
         if matches!((self.previous_top_level_reserved_word, self.options.max_inline_arguments),
             (Some(word), Some(limit)) if ["select", "from"].contains(&word.value.to_lowercase().as_str()) &&
-                limit > self.indentation.top_level_span())
+                limit > self.indentation.span())
         {
             return;
         }
@@ -528,28 +524,33 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    fn top_level_tokens_span(&self) -> usize {
+    fn top_level_tokens_info(&self) -> SpanInfo {
         let mut block_level = self.block_level;
+        let mut full_span = 0;
 
-        self.tokens[self.index..]
-            .iter()
-            .skip(1)
-            .take_while(|token| match token.kind {
+        for token in self.tokens[self.index..].iter().skip(1) {
+            match token.kind {
                 TokenKind::OpenParen => {
                     block_level += 1;
-                    true
                 }
                 TokenKind::CloseParen => {
                     block_level = block_level.saturating_sub(1);
-                    block_level > self.block_level
+                    if block_level < self.block_level {
+                        break;
+                    }
                 }
                 TokenKind::ReservedTopLevel | TokenKind::ReservedTopLevelNoIndent => {
-                    block_level != self.block_level
+                    if block_level == self.block_level {
+                        break;
+                    }
                 }
-                _ => true,
-            })
-            .map(|token| token.value.len())
-            .sum()
+                _ => {}
+            }
+
+            full_span += token.value.len();
+        }
+
+        SpanInfo { full_span }
     }
 
     fn format_no_change(&self, token: &Token<'_>, query: &mut String) {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -101,10 +101,6 @@ pub(crate) fn format(
                 formatter.format_newline_reserved_word(token, &mut formatted_query);
                 formatter.previous_reserved_word = Some(token);
             }
-            TokenKind::Join => {
-                formatter.format_newline_reserved_word(token, &mut formatted_query);
-                formatter.previous_reserved_word = Some(token);
-            }
             TokenKind::Reserved => {
                 formatter.format_with_spaces(token, &mut formatted_query);
                 formatter.previous_reserved_word = Some(token);

--- a/src/indentation.rs
+++ b/src/indentation.rs
@@ -1,9 +1,9 @@
-use crate::{FormatOptions, Indent};
+use crate::{FormatOptions, Indent, SpanInfo};
 
 pub(crate) struct Indentation<'a> {
     options: &'a FormatOptions<'a>,
     indent_types: Vec<IndentType>,
-    top_level_span: Vec<usize>,
+    top_level_span: Vec<SpanInfo>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,7 +30,7 @@ impl<'a> Indentation<'a> {
         }
     }
 
-    pub fn increase_top_level(&mut self, span: usize) {
+    pub fn increase_top_level(&mut self, span: SpanInfo) {
         self.indent_types.push(IndentType::TopLevel);
         self.top_level_span.push(span);
     }
@@ -60,7 +60,8 @@ impl<'a> Indentation<'a> {
         self.top_level_span.clear();
     }
 
-    pub fn top_level_span(&self) -> usize {
-        self.top_level_span.last().map_or(0, |span| *span)
+    /// The full span between two top level tokens
+    pub fn span(&self) -> usize {
+        self.top_level_span.last().map_or(0, |span| span.full_span)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2218,4 +2218,26 @@ from
 
         assert_eq!(format(input, &QueryParams::None, &options), expected);
     }
+
+    #[test]
+    fn parse_union_all() {
+        let input = "SELECT id FROM a UNION ALL SELECT id FROM b WHERE c = $12 AND f";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            SELECT
+              id
+            FROM
+              a
+            UNION ALL
+            SELECT
+              id
+            FROM
+              b
+            WHERE
+              c = $12
+              AND f"
+        );
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ mod tests {
         let options = FormatOptions::default();
         let expected = indoc!(
             "
-            SELECT
-              DISTINCT name,
+            SELECT DISTINCT
+              name,
               ROUND(age / 7) field1,
               18 + 20 AS field2,
               'some string'
@@ -408,8 +408,8 @@ mod tests {
         let options = FormatOptions::default();
         let expected = indoc!(
             "
-            select
-              distinct *
+            select distinct
+              *
             frOM
               foo
               left join bar
@@ -1006,8 +1006,8 @@ mod tests {
         };
         let expected = indoc!(
             "
-            SELECT
-              DISTINCT *
+            SELECT DISTINCT
+              *
             FROM
               foo
               LEFT JOIN bar
@@ -2012,8 +2012,8 @@ mod tests {
         };
         let expected = indoc!(
             "
-            select
-              distinct *
+            select distinct
+              *
             from
               foo
               left join bar
@@ -2062,8 +2062,8 @@ mod tests {
         };
         let expected = indoc!(
             "
-            select
-              distinct *
+            select distinct
+              *
             frOM
               foo
               left join bar

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,12 @@ pub enum QueryParams {
     None,
 }
 
+#[derive(Default)]
+pub(crate) struct SpanInfo {
+    pub full_span: usize,
+    // potentially comma span info here
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2140,14 +2146,14 @@ from
     fn it_formats_blocks_inline_or_not() {
         let input = " UPDATE t SET o = ($5 + $6 + $7 + $8),a = CASE WHEN $2
             THEN NULL ELSE COALESCE($3, b) END, b = CASE WHEN $4 THEN NULL ELSE
-            COALESCE($5, b) END, s = (SELECT true FROM bar WHERE bar.foo = $99),
+            COALESCE($5, b) END, s = (SELECT true FROM bar WHERE bar.foo = $99 AND bar.foo > $100),
             c = CASE WHEN $6 THEN NULL ELSE COALESCE($7, c) END,
-            d = CASE WHEN $8 THEN NULL ELSE COALESCE($9, d) END,
+            d = CASE WHEN $8 THEN NULL ELSE COALESCE($9, dddddddd) + bbbbb END,
             e = (SELECT true FROM bar) WHERE id = $1";
         let options = FormatOptions {
-            max_inline_arguments: Some(50),
-            max_inline_block: 100,
-            max_inline_top_level: Some(10),
+            max_inline_arguments: Some(60),
+            max_inline_block: 60,
+            max_inline_top_level: Some(60),
             ..Default::default()
         };
         let expected = indoc!(
@@ -2157,9 +2163,17 @@ from
             o = ($5 + $6 + $7 + $8),
             a = CASE WHEN $2 THEN NULL ELSE COALESCE($3, b) END,
             b = CASE WHEN $4 THEN NULL ELSE COALESCE($5, b) END,
-            s = (SELECT true FROM bar WHERE bar.foo = $99),
+            s = (
+              SELECT true
+              FROM bar
+              WHERE bar.foo = $99
+              AND bar.foo > $100
+            ),
             c = CASE WHEN $6 THEN NULL ELSE COALESCE($7, c) END,
-            d = CASE WHEN $8 THEN NULL ELSE COALESCE($9, d) END,
+            d = CASE
+              WHEN $8 THEN NULL
+              ELSE COALESCE($9, dddddddd) + bbbbb
+            END,
             e = (SELECT true FROM bar)
           WHERE id = $1"
         );

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -464,9 +464,9 @@ fn get_top_level_reserved_token<'a>(
             'R' => terminated("RETURNING", end_of_word).parse_next(&mut uc_input),
 
             'S' => alt((
-                terminated("SELECT", end_of_word),
                 terminated("SELECT DISTINCT", end_of_word),
                 terminated("SELECT ALL", end_of_word),
+                terminated("SELECT", end_of_word),
                 terminated("SET CURRENT SCHEMA", end_of_word),
                 terminated("SET SCHEMA", end_of_word),
                 terminated("SET", end_of_word),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -638,11 +638,11 @@ fn get_top_level_reserved_token_no_indent<'i>(input: &mut &'i str) -> Result<Tok
     let result: Result<&str> = alt((
         terminated("BEGIN", end_of_word),
         terminated("DECLARE", end_of_word),
-        terminated("INTERSECT", end_of_word),
         terminated("INTERSECT ALL", end_of_word),
+        terminated("INTERSECT", end_of_word),
         terminated("MINUS", end_of_word),
-        terminated("UNION", end_of_word),
         terminated("UNION ALL", end_of_word),
+        terminated("UNION", end_of_word),
         terminated("WITH", end_of_word),
         terminated("$$", end_of_word),
     ))

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -8,7 +8,13 @@ use winnow::prelude::*;
 use winnow::token::{any, one_of, rest, take, take_until, take_while};
 use winnow::Result;
 
-pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'_>> {
+use crate::FormatOptions;
+
+pub(crate) fn tokenize<'a>(
+    mut input: &'a str,
+    named_placeholders: bool,
+    options: &FormatOptions,
+) -> Vec<Token<'a>> {
     let mut tokens: Vec<Token> = Vec::new();
 
     let mut last_reserved_token = None;
@@ -19,17 +25,28 @@ pub(crate) fn tokenize(mut input: &str, named_placeholders: bool) -> Vec<Token<'
     }
 
     // Keep processing the string until it is empty
-    while let Ok(result) = get_next_token(
+    while let Ok(mut result) = get_next_token(
         &mut input,
         tokens.last().cloned(),
         last_reserved_token.clone(),
         last_reserved_top_level_token.clone(),
         named_placeholders,
     ) {
-        if result.kind == TokenKind::Reserved {
-            last_reserved_token = Some(result.clone());
-        } else if result.kind == TokenKind::ReservedTopLevel {
-            last_reserved_top_level_token = Some(result.clone());
+        match result.kind {
+            TokenKind::Reserved => {
+                last_reserved_token = Some(result.clone());
+            }
+            TokenKind::ReservedTopLevel => {
+                last_reserved_top_level_token = Some(result.clone());
+            }
+            TokenKind::Join => {
+                if options.joins_as_top_level {
+                    result.kind = TokenKind::ReservedTopLevel;
+                } else {
+                    result.kind = TokenKind::ReservedNewline;
+                }
+            }
+            _ => {}
         }
 
         tokens.push(result);


### PR DESCRIPTION
Fix again the span computation, make so the compact representation does not behave weirdly when it needs to go columnar in subqueries.

Now it is really getting closer to ideal if somebody wants a compact representation.

Yet to be done: 
- [x] Adding an option to consider `* JOIN` a top level keyword or not.
- [ ] Possibly more tests to catch ugly corner cases.