### PR TITLE
Keep the previous tokens per-block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2054,6 +2054,49 @@ mod tests {
     }
 
     #[test]
+    fn format_nested_select_nested_blocks() {
+        let input =
+            "WITH a AS ( SELECT a, b, c FROM t WHERE a > 100 ), aa AS ( SELECT field FROM table ),
+            bb AS ( SELECT count(*) as c FROM d ), cc AS ( INSERT INTO C (a, b, c, d) VALUES (1 ,2 ,3 ,4) )
+        SELECT b, field FROM a, aa;";
+        let max_line = 20;
+        let options = FormatOptions {
+            max_inline_block: max_line,
+            max_inline_arguments: Some(max_line),
+            max_inline_top_level: Some(max_line / 2),
+            joins_as_top_level: true,
+            ..Default::default()
+        };
+        let expected = indoc! {
+            "
+            WITH
+            a AS (
+              SELECT a, b, c
+              FROM t
+              WHERE a > 100
+            ),
+            aa AS (
+              SELECT field
+              FROM table
+            ),
+            bb AS (
+              SELECT
+                count(*) as c
+              FROM d
+            ),
+            cc AS (
+              INSERT INTO
+                C (a, b, c, d)
+              VALUES
+                (1, 2, 3, 4)
+            )
+            SELECT b, field
+            FROM a, aa;"
+        };
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
+
+    #[test]
     fn it_converts_keywords_nothing_when_no_option_passed_in() {
         let input = "select distinct * frOM foo left join bar WHERe cola > 1 and colb = 3";
         let options = FormatOptions {


### PR DESCRIPTION
This way WITH with nested queries are formatted correctly