### PR TITLE
Relax again the braced placeholder tokenizer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1786,6 +1786,20 @@ mod tests {
             expected
         );
     }
+    #[test]
+    fn it_formats_raw_sql_and_conditional_queries() {
+        let input = "SELECT {foo: &[T]}, {b.c()}, {d.e};";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            SELECT
+              {foo: &[T]},
+              {b.c()},
+              {d.e};"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
 
     #[test]
     fn it_formats_query_with_go_batch_separator() {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -384,22 +384,18 @@ fn get_ident_named_placeholder_token<'i>(input: &mut &'i str) -> Result<Token<'i
 }
 
 fn get_braced_named_placeholder_token<'i>(input: &mut &'i str) -> Result<Token<'i>> {
-    delimited(
-        '{',
-        take_while(1.., |c: char| c.is_alphanumeric() || c == '_'),
-        '}',
-    )
-    .with_taken()
-    .parse_next(input)
-    .map(|(index, token)| {
-        let index = Cow::Borrowed(index);
-        Token {
-            kind: TokenKind::Placeholder,
-            value: token,
-            key: Some(PlaceholderKind::Named(index)),
-            alias: token,
-        }
-    })
+    delimited('{', take_until(1.., '}'), '}')
+        .with_taken()
+        .parse_next(input)
+        .map(|(index, token)| {
+            let index = Cow::Borrowed(index);
+            Token {
+                kind: TokenKind::Placeholder,
+                value: token,
+                key: Some(PlaceholderKind::Named(index)),
+                alias: token,
+            }
+        })
 }
 
 fn get_string_named_placeholder_token<'i>(


### PR DESCRIPTION
The assumption that we store only alphanumerics does not hold see [sqlx-conditional-queries](https://docs.rs/sqlx-conditional-queries/latest/sqlx_conditional_queries/macro.conditional_query_as.html) and [sea-query](https://docs.rs/sea-query/1.0.0-rc.9/sea_query/index.html#4-improved-raw-sql-ergonomics)