### PR TITLE
Fix ON DELETE SET NULL formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2347,6 +2347,31 @@ mod tests {
     }
 
     #[test]
+    fn it_recognizes_on_delete_set_null_clause() {
+        let input = indoc!(
+            "CREATE TABLE t (
+              c1 INT REFERENCES r (id) ON DELETE SET NULL,
+              c2 TEXT
+            );"
+        );
+        let options = FormatOptions {
+            uppercase: Some(true),
+            lines_between_queries: 2,
+            max_inline_top_level: Some(80),
+            ..Default::default()
+        };
+        let expected = indoc!(
+            "
+          CREATE TABLE t (
+            c1 INT REFERENCES r (id) ON DELETE SET NULL,
+            c2 TEXT
+          );"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
+
+    #[test]
     fn it_formats_except_on_columns() {
         let input = indoc!(
             "SELECT table_0.* EXCEPT (profit),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -614,6 +614,7 @@ fn get_top_level_reserved_token<'a>(
                 terminated("SELECT", end_of_word),
                 terminated("SET CURRENT SCHEMA", end_of_word),
                 terminated("SET SCHEMA", end_of_word),
+                terminated("SET NULL", end_of_word),
                 terminated("SET", end_of_word),
             ))
             .parse_next(&mut uc_input),
@@ -648,6 +649,7 @@ fn get_top_level_reserved_token<'a>(
                 {
                     TokenKind::Reserved
                 }
+                ("SET NULL", _) => TokenKind::Reserved,
                 ("SET", Some("UPDATE")) => TokenKind::ReservedNewlineAfter,
                 ("USING", v) if v != Some("MERGE INTO") && v != Some("DELETE FROM") => {
                     TokenKind::Reserved


### PR DESCRIPTION
Fixes #132.

## Summary
- Treat `SET NULL` as a regular reserved phrase so foreign-key actions like `ON DELETE SET NULL` do not split at `SET`.
- Add a regression test covering the reported table definition and formatting options.

## Validation
- `cargo fmt --check`
- `cargo test`
- Manual CLI repro for the issue input now keeps `ON DELETE SET NULL` on the column definition line.