### PR TITLE
fix: add missing `OR REPLACE` to tokenizer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2193,6 +2193,22 @@ mod tests {
     }
 
     #[test]
+    fn it_keeps_create_or_replace_statement_together() {
+        let input = "CREATE OR REPLACE VIEW abc AS SELECT * FROM table;";
+        let options = FormatOptions::default();
+        let expected = indoc!(
+            "
+            CREATE OR REPLACE VIEW abc AS
+            SELECT
+              *
+            FROM
+              table;"
+        );
+
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
+
+    #[test]
     fn it_formats_pgplsql() {
         let input = "CREATE FUNCTION abc() AS $$ DECLARE a int := 1; b int := 2; BEGIN SELECT * FROM table $$ LANGUAGE plpgsql;";
         let options = FormatOptions::default();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -509,7 +509,7 @@ fn get_top_level_reserved_token<'a>(
         // First peek at the first character to determine which group to check
         let first_char = peek(any).parse_next(input)?.to_ascii_uppercase();
 
-        let create_or_replace = (
+        let creatable = (
             "AGGREGATE",
             "FUNCTION",
             "LANGUAGE",
@@ -519,9 +519,7 @@ fn get_top_level_reserved_token<'a>(
             "VIEW",
         );
 
-        let alterable_or_droppable = alt((alt(create_or_replace), "TABLE", "INDEX"));
-        let create_or_replace = alt(create_or_replace);
-
+        let alterable_or_droppable = alt((alt(creatable), "TABLE", "INDEX"));
         // Match keywords based on their first letter
         let result: Result<&str> = match first_char {
             'A' => alt((
@@ -534,7 +532,7 @@ fn get_top_level_reserved_token<'a>(
                 (
                     "CREATE ",
                     alt((
-                        create_or_replace,
+                        (opt("OR REPLACE "), alt(creatable)).take(),
                         (opt("UNIQUE "), "INDEX").take(),
                         (
                             opt(alt((


### PR DESCRIPTION
Close #60

I inlined `create_or_replace` to make it clearer.