### PR TITLE
fix: correctly indent multiline GROUP BY arguments

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -733,9 +733,10 @@ impl<'a> Formatter<'a> {
 
         // if we are going to format a list of arguments take in account also the limit for
         // arguments
-        let arguments_limit = self.options.max_inline_arguments.unwrap_or(0);
-        let newline_after = if arguments > 1 && arguments_limit != 0 {
-            arguments_limit.min(limit) < full_span
+        let newline_after = if arguments > 1 {
+            self.options
+                .max_inline_arguments
+                .is_none_or(|arguments_limit| arguments_limit.min(limit) < full_span)
         } else {
             limit < full_span
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,24 @@ mod tests {
     }
 
     #[test]
+    fn keep_multiline_top_level_arguments_indented() {
+        let input = "SELECT * FROM table1 GROUP BY column1, column2;";
+        let options = FormatOptions {
+            max_inline_top_level: Some(80),
+            ..Default::default()
+        };
+        let expected = indoc! {
+            "
+            SELECT *
+            FROM table1
+            GROUP BY
+              column1,
+              column2;"
+        };
+        assert_eq!(format(input, &QueryParams::None, &options), expected);
+    }
+
+    #[test]
     fn inline_arguments_when_possible() {
         let input = indoc! {
             "


### PR DESCRIPTION
before:
```
GROUP BY column1,
  column2;
```
after:
```
GROUP BY
  column1,
  column2;
```